### PR TITLE
fix: fix skipped tests regex

### DIFF
--- a/demo/file.js
+++ b/demo/file.js
@@ -9,6 +9,7 @@ function nothing() {
 ;/\/\/todo will not be counted/
 // todowillnotbecounted
 
-// SKIP: this will be counted
-//SKIP: this will be counted
-// skip  this will be counted
+// it.skip
+// describe.skip
+//SKIP: this will be NOT counted
+// skip  this will be NOt counted

--- a/demo/subdirectory/file.js
+++ b/demo/subdirectory/file.js
@@ -10,6 +10,7 @@ function nothing() {
 // todowillnotbecounted
 // TODO add another valid todo
 
-// SKIP: this will be counted
-//SKIP: this will be counted
-// skip  this will be counted
+// it.skip
+// describe.skip
+//SKIP: this will be NOT counted
+// skip  this will be NOt counted

--- a/src/searchSkippedTestsInFilesInDirectory.js
+++ b/src/searchSkippedTestsInFilesInDirectory.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const util = require('util')
 const { getFilesInDirectory, getCount } = require('./utils')
 const debug = require('debug')('searchTodosInFilesInDirectory')
-const skippedTestRegex = /\/{2}\s?skip(\s|:)?/gi
+const skippedTestRegex = /\.skip/gi
 
 /**
  * Function to get total count of todos within files matching ext within

--- a/test/searchSkippedTestsInFilesInDirectory-test.js
+++ b/test/searchSkippedTestsInFilesInDirectory-test.js
@@ -5,7 +5,7 @@ const searchSkippedTestsInFilesInDirectory = require('../src/searchSkippedTestsI
 test('searchSkippedTestsInFilesInDirectory returns a number', (t) => {
   mock({
     fakeDir: {
-      'mockFile1.js': '//skip\n// skip',
+      'mockFile1.js': 'it.skip\ndescribe.skip',
       'empty-dir': {},
       sub: {
         'mockFile2.js': '// skip:',
@@ -17,19 +17,19 @@ test('searchSkippedTestsInFilesInDirectory returns a number', (t) => {
   t.true(typeof num === 'number')
 })
 
-test('searchSkippedTestsInFilesInDirectory returns count of 3', (t) => {
+test('searchSkippedTestsInFilesInDirectory returns count of 2', (t) => {
   mock({
     fakeDir: {
-      'mockFile1.js': '//skip\n// skip',
+      'mockFile1.js': 'it.skip\n// skip:',
       'empty-dir': {},
       sub: {
-        'mockFile2.js': '// skip:',
+        'mockFile2.js': 'describe.skip',
       },
       'mockFile.java': '',
     },
   })
   const num = searchSkippedTestsInFilesInDirectory('fakeDir', '.js')
-  t.true(num >= 1)
+  t.true(num == 2)
 })
 
 test('searchSkippedTestsInFilesInDirectory should return empty string with null directory', (t) => {


### PR DESCRIPTION
-update regex to capture `.skip` instead of `SKIP:`
-update skipped tests
-update demo skips