### PR TITLE
fix: use the same debug string plus print the count

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Examples of TODO's that will be counted:
 //todo: this is be counted
 // todo this will be counted
 ```
+
 ## Skipped Test Count
 
 The following will search for skipped tests in `foo/bar` directory and a subdirectories in files matching the `.js` extension.
@@ -33,35 +34,41 @@ Examples of Skipped Tests that will be counted:
 // skip this will be counted
 ```
 
-
 ## Expects
 
 The following table structures are expected in your `README` file with `Date` cells including a `<date>` tag and the `Todo Count`/`Skipped Tests Count`
 cells including a `<todoCounter>`/`<skippedTestsCounter>` tag. If one is not found, the counter will append one at the end of the `README` file.
 
-| Date | Todo Count |
-| :---:| :---:|
-|<date>02/02/02|<todoCounter>2|
-|<date>03/03/03|<todoCounter>3|
-|<date>04/04/04|<todoCounter>4|
-|<date>05/05/05|<todoCounter>5|
-|<date>06/06/06|<todoCounter>6|
-|<date>07/07/07|<todoCounter>7|
-|<date>08/08/08|<todoCounter>8|
-|<date>09/09/09|<todoCounter>9|
-|<date>10/10/10|<todoCounter>10|
-|<date>08/23/23|<todoCounter>11|
+|      Date      |   Todo Count    |
+| :------------: | :-------------: |
+| <date>02/02/02 | <todoCounter>2  |
+| <date>03/03/03 | <todoCounter>3  |
+| <date>04/04/04 | <todoCounter>4  |
+| <date>05/05/05 | <todoCounter>5  |
+| <date>06/06/06 | <todoCounter>6  |
+| <date>07/07/07 | <todoCounter>7  |
+| <date>08/08/08 | <todoCounter>8  |
+| <date>09/09/09 | <todoCounter>9  |
+| <date>10/10/10 | <todoCounter>10 |
+| <date>08/23/23 | <todoCounter>11 |
 
+|      Date      |   Skipped Tests Count   |
+| :------------: | :---------------------: |
+| <date>01/01/01 | <skippedTestsCounter>1  |
+| <date>02/02/02 | <skippedTestsCounter>2  |
+| <date>03/03/03 | <skippedTestsCounter>3  |
+| <date>04/04/04 | <skippedTestsCounter>4  |
+| <date>05/05/05 | <skippedTestsCounter>5  |
+| <date>06/06/06 | <skippedTestsCounter>6  |
+| <date>07/07/07 | <skippedTestsCounter>7  |
+| <date>08/08/08 | <skippedTestsCounter>8  |
+| <date>09/09/09 | <skippedTestsCounter>9  |
+| <date>10/10/10 | <skippedTestsCounter>10 |
 
-| Date | Skipped Tests Count |
-| :---:| :---:|
-|<date>01/01/01|<skippedTestsCounter>1|
-|<date>02/02/02|<skippedTestsCounter>2|
-|<date>03/03/03|<skippedTestsCounter>3|
-|<date>04/04/04|<skippedTestsCounter>4|
-|<date>05/05/05|<skippedTestsCounter>5|
-|<date>06/06/06|<skippedTestsCounter>6|
-|<date>07/07/07|<skippedTestsCounter>7|
-|<date>08/08/08|<skippedTestsCounter>8|
-|<date>09/09/09|<skippedTestsCounter>9|
-|<date>10/10/10|<skippedTestsCounter>10|
+## Debugging
+
+Run this utility with the operating system variable `DEBUG=todo-counter`, for example
+
+```
+$ todo-counter npx count ...
+```

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,14 @@ const searchTodosInFilesInDirectory = require('./searchTodosInFilesInDirectory')
 const searchSkippedTestsInFilesInDirectory = require('./searchSkippedTestsInFilesInDirectory')
 const maybeUpdateReadMeCounter = require('./readmeTableUpdates/updateReadme')
 const { COUNT_TYPE } = require('./readmeTableUpdates/utils')
+const debug = require('debug')('todo-counter')
 
 function todoCounter(dir, ext) {
   lazyAss(is.unemptyString(dir), 'expected', dir, 'to be a string')
   lazyAss(check.unemptyString(ext), 'expected', ext, 'to be a string')
 
   const currentTodos = searchTodosInFilesInDirectory(dir, ext)
+  debug('found %d todo(s) in the directory %s', currentTodos, dir)
 
   lazyAss(
     is.number(currentTodos),
@@ -25,6 +27,7 @@ function skippedTestCounter(dir, ext) {
   lazyAss(check.unemptyString(ext), 'expected', ext, 'to be a string')
 
   const skippedTests = searchSkippedTestsInFilesInDirectory(dir, ext)
+  debug('found %d skipped test(s) in the directory %s', skippedTests, dir)
 
   lazyAss(
     is.number(skippedTests),

--- a/src/readmeTableUpdates/updateReadme.js
+++ b/src/readmeTableUpdates/updateReadme.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
-const debug = require('debug')('updateReadMeTodoCounter')
+const debug = require('debug')('todo-counter')
+
 const {
   extractTableFromReadme,
   maybeUpdateReadmeTable,
@@ -15,6 +16,8 @@ const {
 function maybeUpdateReadMeCounter(count, countType) {
   const readmeFile = 'README.md'
   let headerString, tableHeaderTag
+
+  debug({ count, countType })
 
   if (countType == COUNT_TYPE.TODO.type) {
     headerString = 'Todo'

--- a/src/readmeTableUpdates/utils.js
+++ b/src/readmeTableUpdates/utils.js
@@ -1,5 +1,5 @@
 const dayjs = require('dayjs')
-const debug = require('debug')('updateReadMeTodoCounter')
+const debug = require('debug')('todo-counter')
 const fs = require('fs')
 const util = require('util')
 
@@ -176,7 +176,7 @@ function maybeUpdateReadmeTable(
       debug('ReadMe file updated!')
     })
   } else {
-    console.log('No change in count')
+    console.log('No change in count %d', foundCount)
   }
 }
 

--- a/src/searchSkippedTestsInFilesInDirectory.js
+++ b/src/searchSkippedTestsInFilesInDirectory.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const util = require('util')
 const { getFilesInDirectory, getCount } = require('./utils')
-const debug = require('debug')('searchTodosInFilesInDirectory')
+const debug = require('debug')('todo-counter')
+
 const skippedTestRegex = /\.skip/gi
 
 /**

--- a/src/searchTodosInFilesInDirectory.js
+++ b/src/searchTodosInFilesInDirectory.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const util = require('util')
 const { getFilesInDirectory, getCount } = require('./utils')
-const debug = require('debug')('searchTodosInFilesInDirectory')
+const debug = require('debug')('todo-counter')
+
 const todoRegex = /\/{2}\s?todo(\s|:)?/gi
 
 /**


### PR DESCRIPTION
- using the same debug value as the module name makes it simple to see what it is doing
- added a few more debug logs
- print the count even if unchanged